### PR TITLE
add editannotate to the list of cq:actions

### DIFF
--- a/help/sites-developing/components-basics.md
+++ b/help/sites-developing/components-basics.md
@@ -622,6 +622,10 @@ The `cq:actions` property ( `String array`) defines one or several actions that 
    <td>Adds a button to edit the component.</td>
   </tr>
   <tr>
+   <td><code>editannotate</code></td>
+   <td>Adds a button to edit the component as well as allowing <a href="/help/sites-authoring/annotations.md">annotations</a>.</td>
+  </tr>
+  <tr>
    <td><code>delete</code></td>
    <td>Adds a button to delete the component</td>
   </tr>


### PR DESCRIPTION
*editannotate* allows a component to be edited and annotated.
Reference: https://experienceleaguecommunities.adobe.com/t5/Adobe-Experience-Manager/Enabling-Annotations-in-custom-components-touchUI/qaq-p/198320/comment-id/19726