### PR TITLE
Update clientlibs.md

### DIFF
--- a/help/sites-developing/clientlibs.md
+++ b/help/sites-developing/clientlibs.md
@@ -427,9 +427,9 @@ Opening the `publicmain.css` file reveals the following code:
 
 ### Discover Client Libraries {#discover-client-libraries}
 
-The `/libs/cq/ui/components/dumplibs/dumplibs` component generates a page of information about all client library folders on the system. The `/libs/cq/ui/content/dumplibs` node has the component as a resource type. To open the page, use the following URL (use a different host and port as required):
+The `/libs/cq/granite/components/dumplibs/dumplibs` component generates a page of information about all client library folders on the system. The `/libs/granite/ui/content/dumplibs` node has the component as a resource type. To open the page, use the following URL (use a different host and port as required):
 
-[https://localhost:4502/libs/cq/ui/content/dumplibs.test.html](https://localhost:4502/libs/cq/ui/content/dumplibs.test.html)
+[https://localhost:4502/libs/granite/ui/content/dumplibs.test.html](https://localhost:4502/libs/granite/ui/content/dumplibs.test.html)
 
 The information includes the library path and type (CSS or JS), and the values of the library attributes, such as categories and dependencies. Subsequent tables on the page show the libraries in each category and channel.
 
@@ -443,7 +443,7 @@ The `dumplibs` component includes a test selector that displays the source code 
 
     * Open the following URL in your web browser (use a different host and port as required):
 
-      [https://localhost:4502/libs/cq/ui/content/dumplibs.html](https://localhost:4502/libs/cq/ui/content/dumplibs.html)
+      [https://localhost:4502/libs/granite/ui/content/dumplibs.html](https://localhost:4502/libs/granite/ui/content/dumplibs.html)
 
    The default page shows output for tags with no value for the categories attribute.
 


### PR DESCRIPTION
/libs/cq/ui/content/dumplibs component doesn't exists any more , new path is /libs/granite/ui/content/dumplibs