### PR TITLE
(maint) Fix backtick escaping for markdown

### DIFF
--- a/help/assets/content-fragments/content-fragments-markdown.md
+++ b/help/assets/content-fragments/content-fragments-markdown.md
@@ -191,7 +191,7 @@ Backslash escapes are available for the following characters:
 
 &nbsp;&nbsp;&nbsp;&nbsp;`\ backslash`
 
-&nbsp;&nbsp;&nbsp;&nbsp;` backtick
+&nbsp;&nbsp;&nbsp;&nbsp;`` ` backtick``
 
 &nbsp;&nbsp;&nbsp;&nbsp;`* asterisk`
 


### PR DESCRIPTION
Previously the formatting did not actually escape the backtick properly which made the text not confirm to all the other items in the list.  This commit uses the double backtick to indicate the code block instead of single backtick.