### PR TITLE
Update content-fragment-templates.md

### DIFF
--- a/help/sites-developing/content-fragment-templates.md
+++ b/help/sites-developing/content-fragment-templates.md
@@ -22,7 +22,7 @@ exl-id: 1b75721c-b223-41f0-88d9-bd855b529f31
 
 >[!NOTE]
 >
->Prior to AEM 6.3 Content Fragments were created with the use of templates instead of models. Templates are no longer available for creating new fragments, but any fragments created with such a template are still supported.
+>Prior to AEM 6.3 Content Fragments were created with the use of templates instead of models. As of AEM 6.5.10, templates are no longer available for creating new fragments, but any fragments created with such a template are still supported.
 
 Templates are selected when creating a content fragment. They provide the new fragment with the basic structure, element(s) and variation. The templates used for content fragments are subject to the Granite Configuration Manager.
 


### PR DESCRIPTION
added "As of AEM 6.5.10," in note about simple content fragment templates no longer available. In general, we should add timing information for such notes so that some time down the road it's clear as of when the change applied.