### PR TITLE
clientlibs in `/etc` -> proxy servlet

### DIFF
--- a/help/sites-developing/clientlibs.md
+++ b/help/sites-developing/clientlibs.md
@@ -218,7 +218,7 @@ Embedding code is useful for providing access to libraries that are stored in se
 
 #### App-Specific Client Library Folders {#app-specific-client-library-folders}
 
-It is a best practice to keep all application-related files in their application folder below `/app`. It is also a best practice to deny access for web site visitors to the `/app` folder. To satisfy both best practices, create a client library folder below the `/etc` folder that embeds the client library that is below `/app`.
+It is a best practice to keep all application-related files in their application folder below `/apps`. It is also a best practice to deny access for web site visitors to the `/apps` folder. To satisfy both best practices, create a client library folder below `/apps` and make it accessible through the proxy servlet as described in [Locating a Client Library Folder and Using the Proxy Client Libraries Servlet](/help/sites-developing/clientlibs.md#locating-a-client-library-folder-and-using-the-proxy-client-libraries-servlet) above.
 
 Use the categories property to identify the client library folder to embed. To embed the library, add a property to the embedding `cq:ClientLibraryFolder` node, using the following property attributes:
 


### PR DESCRIPTION
paragraph still references outdated patter on using `/etc`. + typos