### PR TITLE
Fix spacing issues in Adaptive Forms documentation

### DIFF
--- a/help/forms/using/adaptive-forms-best-practices.md
+++ b/help/forms/using/adaptive-forms-best-practices.md
@@ -10,7 +10,7 @@ role: Admin, User, Developer
 ---
 # Best practices for working with adaptive forms {#best-practices-for-working-with-adaptive-forms}
 
-<span class="preview"> Adobe recommends using the modern and extensible data capture [Core Components](https://experienceleague.adobe.com/docs/experience-manager-core-components/using/adaptive-forms/introduction.html) for [creating new Adaptive Forms](/help/forms/using/create-an-adaptive-form-core-components.md) or [adding Adaptive Forms to AEM Sites pages](/help/forms/using/create-or-add-an-adaptive-form-to-aem-sites-page.md). These components represent a significant advancement in Adaptive Forms creation, ensuring impressive user experiences. This article describes older approach to author Adaptive Forms using foundation components. </span>
+<span class="preview"> Adobe recommends using the modern and extensible data capture [Core Components](https://experienceleague.adobe.com/docs/experience-manager-core-components/using/adaptive-forms/introduction.html) &nbsp;for [creating new Adaptive Forms](/help/forms/using/create-an-adaptive-form-core-components.md) &nbsp;or [adding Adaptive Forms to AEM Sites pages](/help/forms/using/create-or-add-an-adaptive-form-to-aem-sites-page.md). These components represent a significant advancement in Adaptive Forms creation, ensuring impressive user experiences. This article describes older approach to author Adaptive Forms using foundation components. </span>
 
 ## Overview {#overview}
 


### PR DESCRIPTION
Corrected spelling issues in the Adaptive Forms documentation by adding missing spaces in "Componentsfor" (now "Components for") and "Formsor" (now "Forms or"). On the live site, these errors looked abnormal and could confuse readers or lead to misspellings. These adjustments enhance readability and professionalism.